### PR TITLE
Refactor the order.order() method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ python:
 install:
   - pip install -r requirements.txt
 # command to run tests
-script: py.test tests/unit
+script: python unit_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+# command to run tests
+script: py.test tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -57,7 +57,7 @@ The ordered image sits in a directory on S3. The output of the following describ
 .. code-block:: pycon
 
    >>> gbdx.ordering.status(order_id)
-   >>> {u's3://receiving-dgcs-tdgplatform-com/055093376010_01_003': u'delivered'}
+   >>> [{u'acquisition_id': u'10400100120FEA00', u'state': u'delivered', u'location': u's3://bucketname/prefixname'}]
 
 
 GBDX Workflows

--- a/examples/get_images.py
+++ b/examples/get_images.py
@@ -18,9 +18,9 @@ locations = []
 while len(pending_order_ids)>0:
     print 'Pending orders', pending_order_ids
     for order_id in pending_order_ids:
-        result = gbdx.ordering.status(order_id)
-        print result
-        location, status = result.keys()[0], result.values()[0]
+        results = gbdx.ordering.status(order_id)
+        print results
+        location, status = results[0]['location'], results[0]['state']
         if status == 'delivered':
             pending_order_ids.remove(order_id)
             locations.append(location)

--- a/gbdxtools/ordering.py
+++ b/gbdxtools/ordering.py
@@ -67,11 +67,5 @@ class Ordering:
         url = 'https://geobigdata.io/orders/v2/order/'
         r = self.gbdx_connection.get(url + order_id)
         r.raise_for_status()
-        lines = r.json().get("acquisitions", {})
-        results = []
-        for line in lines:
-            location = line['location']
-            status = line["state"]
-            results.append((location, status))
-
-        return dict(results)
+        return r.json().get("acquisitions", {})
+        

--- a/tests/unit/cassettes/test_get_order_status.yaml
+++ b/tests/unit/cassettes/test_get_order_status.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://geobigdata.io/orders/v2/order/c5cd8157-3001-4a03-a716-4ef673748c7a
+  response:
+    body: {string: !!python/unicode '{"order_id": "c5cd8157-3001-4a03-a716-4ef673748c7a",
+        "acquisitions": [{"acquisition_id": "10400100120FEA00", "state": "delivered",
+        "location": "s3://bucketname/prefixname"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-length: ['203']
+      content-type: [application/json]
+      date: ['Sat, 02 Apr 2016 15:35:52 GMT']
+      via: [kong/0.5.2]
+      x-amz-cf-id: [V4Ys2cYYrKf1ns2HbXuZwbrM-Np4-QHk4D_MDSw_hrTg8CFpZB_1pg==]
+      x-amzn-requestid: [9564cb02-f8e8-11e5-892f-d554c4212b14]
+      x-cache: [Miss from cloudfront]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/cassettes/test_order_multi_catids.yaml
+++ b/tests/unit/cassettes/test_order_multi_catids.yaml
@@ -1,0 +1,27 @@
+interactions:
+- request:
+    body: '["10400100120FEA00", "101001000DB2FB00"]'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['40']
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://geobigdata.io/orders/v2/order/
+  response:
+    body: {string: !!python/unicode '{"order_id": "2b3ba38e-4d7e-4ef6-ac9d-2e2e0a8ca1e7",
+        "acquisitions": [{"acquisition_id": "101001000DB2FB00", "state": "delivered",
+        "location": "s3://bucket/fdsa"}, {"acquisition_id":
+        "10400100120FEA00", "state": "delivered", "location": "s3://bucket/asdf"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-length: ['336']
+      content-type: [application/json]
+      date: ['Sat, 02 Apr 2016 15:30:42 GMT']
+      via: [kong/0.5.2]
+      x-amz-cf-id: [fdsa-2VzquZ2h5Zq52rUQK67iKA==]
+      x-amzn-requestid: [dc9453a0-f8e7-11e5-a00f-6584be6d2146]
+      x-cache: [Miss from cloudfront]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/cassettes/test_order_single_catid.yaml
+++ b/tests/unit/cassettes/test_order_single_catid.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: '["10400100120FEA00"]'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['20']
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://geobigdata.io/orders/v2/order/
+  response:
+    body: {string: !!python/unicode '{"order_id": "c5cd8157-3001-4a03-a716-4ef673748c7a",
+        "acquisitions": [{"acquisition_id": "10400100120FEA00", "state": "delivered",
+        "location": "s3://bucket/prefix"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-length: ['203']
+      content-type: [application/json]
+      date: ['Sat, 02 Apr 2016 15:27:53 GMT']
+      via: [kong/0.5.2]
+      x-amz-cf-id: [I-asdfasdf-PY3tdqVS6fEBuiFCbeXXyGOZA==]
+      x-amzn-requestid: [77824d9d-f8e7-11e5-9bb8-352d050ed02a]
+      x-cache: [Miss from cloudfront]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -22,5 +22,6 @@ gbdx = Interface(gbdx_connection = mock_gbdx_session)
 
 def test_init():
     c = Catalog(gbdx)
+    asdf
     assert isinstance(c, Catalog)
 

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -22,6 +22,5 @@ gbdx = Interface(gbdx_connection = mock_gbdx_session)
 
 def test_init():
     c = Catalog(gbdx)
-    asdf
     assert isinstance(c, Catalog)
 

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -7,8 +7,20 @@ Unit tests for the gbdxtools.Catalog class
 
 from gbdxtools import Interface
 from gbdxtools.catalog import Catalog
+import vcr
+from auth_mock import get_mock_gbdx_session
+
+# How to use the mock_gbdx_session and vcr to create unit tests:
+# 1. Add a new test that is dependent upon actually hitting GBDX APIs.
+# 2. Decorate the test with @vcr appropriately
+# 3. replace "dummytoken" with a real gbdx token
+# 4. Run the tests (existing test shouldn't be affected by use of a real token).  This will record a "cassette".
+# 5. replace the real gbdx token with "dummytoken" again
+# 6. Edit the cassette to remove any possibly sensitive information (s3 creds for example)
+mock_gbdx_session = get_mock_gbdx_session(token="dummytoken")
+gbdx = Interface(gbdx_connection = mock_gbdx_session)
 
 def test_init():
-    c = Catalog(Interface())
+    c = Catalog(gbdx)
     assert isinstance(c, Catalog)
 

--- a/tests/unit/test_idaho.py
+++ b/tests/unit/test_idaho.py
@@ -7,8 +7,20 @@ Unit tests for the gbdxtools.Idaho class
 
 from gbdxtools import Interface
 from gbdxtools.idaho import Idaho
+import vcr
+from auth_mock import get_mock_gbdx_session
+
+# How to use the mock_gbdx_session and vcr to create unit tests:
+# 1. Add a new test that is dependent upon actually hitting GBDX APIs.
+# 2. Decorate the test with @vcr appropriately
+# 3. replace "dummytoken" with a real gbdx token
+# 4. Run the tests (existing test shouldn't be affected by use of a real token).  This will record a "cassette".
+# 5. replace the real gbdx token with "dummytoken" again
+# 6. Edit the cassette to remove any possibly sensitive information (s3 creds for example)
+mock_gbdx_session = get_mock_gbdx_session(token="dummytoken")
+gbdx = Interface(gbdx_connection = mock_gbdx_session)
 
 def test_init():
-    i = Idaho(Interface())
+    i = Idaho(gbdx)
     assert isinstance(i, Idaho)
 

--- a/tests/unit/test_interface.py
+++ b/tests/unit/test_interface.py
@@ -1,6 +1,17 @@
 from gbdxtools import Interface
+import vcr
+from auth_mock import get_mock_gbdx_session
+
+# How to use the mock_gbdx_session and vcr to create unit tests:
+# 1. Add a new test that is dependent upon actually hitting GBDX APIs.
+# 2. Decorate the test with @vcr appropriately
+# 3. replace "dummytoken" with a real gbdx token
+# 4. Run the tests (existing test shouldn't be affected by use of a real token).  This will record a "cassette".
+# 5. replace the real gbdx token with "dummytoken" again
+# 6. Edit the cassette to remove any possibly sensitive information (s3 creds for example)
+mock_gbdx_session = get_mock_gbdx_session(token="dummytoken")
 
 def test_init():
-    gi = Interface()
+    gi = Interface(gbdx_connection = mock_gbdx_session)
     assert isinstance(gi, Interface)
    

--- a/tests/unit/test_ordering.py
+++ b/tests/unit/test_ordering.py
@@ -7,7 +7,19 @@ Unit tests for the gbdxtools.Ordering class
 
 from gbdxtools import Interface
 from gbdxtools.ordering import Ordering
+import vcr
+from auth_mock import get_mock_gbdx_session
+
+# How to use the mock_gbdx_session and vcr to create unit tests:
+# 1. Add a new test that is dependent upon actually hitting GBDX APIs.
+# 2. Decorate the test with @vcr appropriately
+# 3. replace "dummytoken" with a real gbdx token
+# 4. Run the tests (existing test shouldn't be affected by use of a real token).  This will record a "cassette".
+# 5. replace the real gbdx token with "dummytoken" again
+# 6. Edit the cassette to remove any possibly sensitive information (s3 creds for example)
+mock_gbdx_session = get_mock_gbdx_session(token="dummytoken")
+gbdx = Interface(gbdx_connection = mock_gbdx_session)
 
 def test_init():
-    o = Ordering(Interface())
+    o = Ordering(gbdx)
     assert isinstance(o, Ordering)

--- a/tests/unit/test_ordering.py
+++ b/tests/unit/test_ordering.py
@@ -41,7 +41,10 @@ def test_order_multi_catids():
 @vcr.use_cassette('tests/unit/cassettes/test_get_order_status.yaml',filter_headers=['authorization'])
 def test_get_order_status():
 	o = Ordering(gbdx)
-	r = o.status('c5cd8157-3001-4a03-a716-4ef673748c7a')
-	print r.keys()
-	assert 's3://bucketname/prefixname' in r.keys()
+	results = o.status('c5cd8157-3001-4a03-a716-4ef673748c7a')
+	print results
+	for result in results:
+		assert 'acquisition_id' in result.keys()
+		assert 'state' in result.keys()
+		assert 'location' in result.keys()
 

--- a/tests/unit/test_ordering.py
+++ b/tests/unit/test_ordering.py
@@ -23,3 +23,25 @@ gbdx = Interface(gbdx_connection = mock_gbdx_session)
 def test_init():
     o = Ordering(gbdx)
     assert isinstance(o, Ordering)
+
+@vcr.use_cassette('tests/unit/cassettes/test_order_single_catid.yaml',filter_headers=['authorization'])
+def test_order_single_catid():
+	o = Ordering(gbdx)
+	order_id = o.order('10400100120FEA00')
+	# assert order_id == 'c5cd8157-3001-4a03-a716-4ef673748c7a'
+	assert len(order_id) == 36
+
+@vcr.use_cassette('tests/unit/cassettes/test_order_multi_catids.yaml',filter_headers=['authorization'])
+def test_order_multi_catids():
+	o = Ordering(gbdx)
+	order_id = o.order(['10400100120FEA00','101001000DB2FB00'])
+	# assert order_id == '2b3ba38e-4d7e-4ef6-ac9d-2e2e0a8ca1e7'
+	assert len(order_id) == 36
+
+@vcr.use_cassette('tests/unit/cassettes/test_get_order_status.yaml',filter_headers=['authorization'])
+def test_get_order_status():
+	o = Ordering(gbdx)
+	r = o.status('c5cd8157-3001-4a03-a716-4ef673748c7a')
+	print r.keys()
+	assert 's3://bucketname/prefixname' in r.keys()
+

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,2 +1,4 @@
 import pytest
-pytest.main("-s tests/unit")
+r = pytest.main("-s tests/unit")
+if r:
+	raise Exception("There were test failures or errors.")

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,4 +1,4 @@
 import pytest
-r = pytest.main("-s tests/unit")
+r = pytest.main("tests/unit")
 if r:
 	raise Exception("There were test failures or errors.")

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,4 +1,4 @@
 import pytest
-r = pytest.main("tests/unit")
+r = pytest.main("-s tests/unit")
 if r:
 	raise Exception("There were test failures or errors.")

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -1,0 +1,2 @@
+import pytest
+pytest.main("-s tests/unit")


### PR DESCRIPTION
Right now the function returns a set of keys that are s3 locations, and values that are statuses.  If the order is for multiple acquisitions, you can't see what acquisition goes to what catid.  

I propose to return a data structure a bit closer to what the api returns:
```json
[
    {
        "acquisition_id": "10400100120FEA00", 
        "state": "delivered", 
        "location": "s3://bucketname/prefixname"
    }
]
```

This way the keys are always known, and we can access them the same way.